### PR TITLE
Attachment support in Mail Providers through blob storage

### DIFF
--- a/NotificationService/NotificationHandler/Startup.cs
+++ b/NotificationService/NotificationHandler/Startup.cs
@@ -94,6 +94,7 @@ namespace NotificationHandler
                 .AddScoped<ITableStorageClient, TableStorageClient>()
                 .AddScoped<IMailTemplateManager, MailTemplateManager>()
                 .AddScoped<IMailTemplateRepository, MailTemplateRepository>()
+                .AddScoped<IMailAttachmentRepository, MailAttachmentRepository>()
                 .AddScoped<ITemplateMerge, TemplateMerge>()
                 .AddScoped<ITableStorageClient, TableStorageClient>()
                 .AddSingleton<IEmailAccountManager, EmailAccountManager>();

--- a/NotificationService/NotificationHandler/Startup.cs
+++ b/NotificationService/NotificationHandler/Startup.cs
@@ -77,7 +77,8 @@ namespace NotificationHandler
                         s.GetService<ILogger>(),
                         s.GetService<NotificationService.Common.Encryption.IEncryptionService>(),
                         s.GetService<IMailTemplateManager>(),
-                        s.GetService<ITemplateMerge>()))
+                        s.GetService<ITemplateMerge>(),
+                        s.GetService<ICloudStorageClient>()))
                 .AddScoped<IEmailHandlerManager, EmailHandlerManager>(s =>
                     new EmailHandlerManager(
                         this.Configuration,

--- a/NotificationService/NotificationService.BusinessLibrary/Business/v1/EmailManager.cs
+++ b/NotificationService/NotificationService.BusinessLibrary/Business/v1/EmailManager.cs
@@ -141,24 +141,10 @@ namespace NotificationService.BusinessLibrary
                 notificationEntity.CreatedDateTime = DateTime.UtcNow;
                 notificationEntity.UpdatedDateTime = DateTime.UtcNow;
                 notificationEntity.Status = status;
-
-                if (item.Attachments.Any())
-                {
-                    List<string> attachmentReferences = new List<string>();
-                    string blobReference = string.Empty;
-                    foreach (var attachment in item.Attachments)
-                    {
-                        blobReference = await this.cloudStorageClient.UploadAttachmentToBlobAsync(applicationName, notificationEntity.NotificationId, attachment.FileName, attachment.FileBase64).ConfigureAwait(false);
-                        attachmentReferences.Add(blobReference);
-                    }
-
-                    notificationEntity.AttachmentReference = JsonConvert.SerializeObject(attachmentReferences);
-                }
-
                 notificationEntities.Add(notificationEntity);
             }
 
-            await this.emailNotificationRepository.CreateEmailNotificationItemEntities(notificationEntities).ConfigureAwait(false);
+            await this.emailNotificationRepository.CreateEmailNotificationItemEntities(notificationEntities, applicationName).ConfigureAwait(false);
             this.logger.TraceInformation($"Completed {nameof(this.CreateNotificationEntities)} method of {nameof(EmailManager)}.", traceProps);
             return notificationEntities;
         }

--- a/NotificationService/NotificationService.BusinessLibrary/Business/v1/EmailServiceManager.cs
+++ b/NotificationService/NotificationService.BusinessLibrary/Business/v1/EmailServiceManager.cs
@@ -228,7 +228,7 @@ namespace NotificationService.BusinessLibrary.Business.v1
         {
             this.logger.TraceInformation($"Started {nameof(this.SendNotificationsUsingProvider)} method of {nameof(EmailServiceManager)}.");
             IList<EmailNotificationItemEntity> emailNotificationEntities = await this.emailManager.CreateNotificationEntities(applicationName, emailNotificationItems, NotificationItemStatus.Processing).ConfigureAwait(false);
-            IList<EmailNotificationItemEntity> notificationEntities = await this.emailNotificationRepository.GetEmailNotificationItemEntities(emailNotificationEntities.Select(e => e.NotificationId).ToList()).ConfigureAwait(false);
+            IList<EmailNotificationItemEntity> notificationEntities = await this.emailNotificationRepository.GetEmailNotificationItemEntities(emailNotificationEntities.Select(e => e.NotificationId).ToList(), applicationName).ConfigureAwait(false);
             var retEntities = await this.ProcessNotificationEntities(applicationName, notificationEntities).ConfigureAwait(false);
             this.logger.TraceInformation($"Finished {nameof(this.SendNotificationsUsingProvider)} method of {nameof(EmailServiceManager)}.");
             return retEntities;
@@ -251,7 +251,7 @@ namespace NotificationService.BusinessLibrary.Business.v1
             List<string> notificationIds = queueNotificationItem.NotificationIds.ToList();
 
             this.logger.TraceVerbose($"Started {nameof(this.emailNotificationRepository.GetEmailNotificationItemEntities)} method in {nameof(EmailServiceManager)}.", traceProps);
-            IList<EmailNotificationItemEntity> notificationEntities = await this.emailNotificationRepository.GetEmailNotificationItemEntities(notificationIds).ConfigureAwait(false);
+            IList<EmailNotificationItemEntity> notificationEntities = await this.emailNotificationRepository.GetEmailNotificationItemEntities(notificationIds, applicationName).ConfigureAwait(false);
             this.logger.TraceVerbose($"Completed {nameof(this.emailNotificationRepository.GetEmailNotificationItemEntities)} method in {nameof(EmailServiceManager)}.", traceProps);
 
             var notificationEntitiesToBeSkipped = new List<EmailNotificationItemEntity>();

--- a/NotificationService/NotificationService.Contracts/Entities/EmailNotificationItemEntity.cs
+++ b/NotificationService/NotificationService.Contracts/Entities/EmailNotificationItemEntity.cs
@@ -99,6 +99,12 @@ namespace NotificationService.Contracts
         public IEnumerable<NotificationAttachmentEntity> Attachments { get; set; }
 
         /// <summary>
+        /// Gets or sets the attachment reference.
+        /// </summary>
+        [DataMember(Name = "AttachmentReference")]
+        public string AttachmentReference { get; set; }
+
+        /// <summary>
         /// Gets or sets the Sensitivity.
         /// </summary>
         [DataMember(Name = "Sensitivity")]

--- a/NotificationService/NotificationService.Contracts/Entities/EmailNotificationItemTableEntity.cs
+++ b/NotificationService/NotificationService.Contracts/Entities/EmailNotificationItemTableEntity.cs
@@ -98,6 +98,12 @@ namespace NotificationService.Contracts
         public IEnumerable<NotificationAttachmentEntity> Attachments { get; set; }
 
         /// <summary>
+        /// Gets or sets the attachment reference.
+        /// </summary>
+        [DataMember(Name = "AttachmentReference")]
+        public string AttachmentReference { get; set; }
+
+        /// <summary>
         /// Gets or sets the Sensitivity.
         /// </summary>
         [DataMember(Name = "Sensitivity")]

--- a/NotificationService/NotificationService.Contracts/Entities/NotificationAttachmentReference.cs
+++ b/NotificationService/NotificationService.Contracts/Entities/NotificationAttachmentReference.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace NotificationService.Contracts
+{
+    using System.Runtime.Serialization;
+
+    /// <summary>
+    /// Notification Attachment Reference.
+    /// </summary>
+    [DataContract]
+    public class NotificationAttachmentReference
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NotificationAttachmentReference"/> class.
+        /// </summary>
+        public NotificationAttachmentReference()
+        {
+            this.IsInline = false;
+        }
+
+        /// <summary>
+        /// Gets or sets the name of the file.
+        /// </summary>
+        /// <value>
+        /// The name of the file.
+        /// </value>
+        [DataMember(Name = "FileName")]
+        public string FileName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the file base64.
+        /// </summary>
+        [DataMember(Name = "FileReference")]
+        public string FileReference { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether this instance is inline.
+        /// </summary>
+        [DataMember(Name = "IsInline")]
+        public bool IsInline { get; set; }
+    }
+}

--- a/NotificationService/NotificationService.Contracts/Extensions/EmailNotificationItemExtensions.cs
+++ b/NotificationService/NotificationService.Contracts/Extensions/EmailNotificationItemExtensions.cs
@@ -44,7 +44,7 @@ namespace NotificationService.Contracts.Extensions
                     Sensitivity = emailNotificationItem.Sensitivity,
                     Subject = emailNotificationItem?.Subject,
                     To = emailNotificationItem?.To,
-                    TemplateData = emailNotificationItem?.TemplateData != null ? encryptionService.Encrypt(emailNotificationItem?.TemplateData) : null,
+                    TemplateData = !string.IsNullOrEmpty(emailNotificationItem?.TemplateData) ? encryptionService.Encrypt(emailNotificationItem?.TemplateData) : null,
                     TemplateName = emailNotificationItem?.TemplateName,
                     TrackingId = emailNotificationItem?.TrackingId,
                 };

--- a/NotificationService/NotificationService.Data/CloudStorage/CloudStorageClient.cs
+++ b/NotificationService/NotificationService.Data/CloudStorage/CloudStorageClient.cs
@@ -40,7 +40,16 @@ namespace NotificationService.Data
         /// Instance of <see cref="BlobContainerClient"/>.
         /// </summary>
         private readonly BlobContainerClient blobContainerClient;
+
+        /// <summary>
+        /// Instance of <see cref="ILogger"/>.
+        /// </summary>
         private readonly ILogger logger;
+
+        /// <summary>
+        /// Instance of <see cref="BlobContainerClient"/>.
+        /// </summary>
+        private BlobContainerClient attachmentBlobContainerClient;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CloudStorageClient"/> class.
@@ -97,27 +106,18 @@ namespace NotificationService.Data
         }
 
         /// <inheritdoc/>
-        public async Task<string> UploadAttachmentToBlobAsync(string applicationName, string notificationId, string fileName, string content)
+        public async Task<string> UploadAttachmentToBlobAsync(string applicationName, string blobPath, string content)
         {
-            string containerName = applicationName.ToLower(CultureInfo.InvariantCulture);
-            BlobContainerClient attachmentBlobContainerClient = new BlobContainerClient(this.storageAccountSetting.ConnectionString, containerName);
-            if (!attachmentBlobContainerClient.Exists())
-            {
-                this.logger.TraceWarning($"BlobStorageClient - Method: {nameof(CloudStorageClient)} - No container found with name {containerName}.");
+            this.GetAttachmentBlobContainerClient(applicationName);
 
-                var response = attachmentBlobContainerClient.CreateIfNotExists();
-
-                attachmentBlobContainerClient = new BlobContainerClient(this.storageAccountSetting.ConnectionString, containerName);
-            }
-
-            BlobClient blobClient = attachmentBlobContainerClient.GetBlobClient(string.Concat(notificationId, "/", fileName));
+            BlobClient blobClient = this.attachmentBlobContainerClient.GetBlobClient(blobPath);
             var contentBytes = Convert.FromBase64String(content);
             using (var stream = new MemoryStream(contentBytes))
             {
                 var result = await blobClient.UploadAsync(stream, overwrite: true).ConfigureAwait(false);
             }
 
-            return string.Concat(attachmentBlobContainerClient.Uri, "/", notificationId);
+            return blobPath;
         }
 
         /// <inheritdoc/>
@@ -155,6 +155,42 @@ namespace NotificationService.Data
         }
 
         /// <inheritdoc/>
+        public async Task<string> DownloadAttachmentFromBlobAsync(string applicationName, string blobPath)
+        {
+            this.GetAttachmentBlobContainerClient(applicationName);
+
+            BlobClient blobClient = this.attachmentBlobContainerClient.GetBlobClient(blobPath);
+            bool isExists = await blobClient.ExistsAsync().ConfigureAwait(false);
+            if (isExists)
+            {
+                var blob = await blobClient.DownloadAsync().ConfigureAwait(false);
+                byte[] streamArray = new byte[blob.Value.ContentLength];
+                long numBytesToRead = blob.Value.ContentLength;
+                int numBytesRead = 0;
+                int maxBytesToRead = 10;
+                do
+                {
+                    if (numBytesToRead < maxBytesToRead)
+                    {
+                        maxBytesToRead = (int)numBytesToRead;
+                    }
+
+                    int n = blob.Value.Content.Read(streamArray, numBytesRead, maxBytesToRead);
+                    numBytesRead += n;
+                    numBytesToRead -= n;
+                }
+                while (numBytesToRead > 0);
+
+                return Convert.ToBase64String(streamArray);
+            }
+            else
+            {
+                this.logger.TraceWarning($"BlobStorageClient - Method: {nameof(this.DownloadAttachmentFromBlobAsync)} - No blob found with name {blobPath}.");
+                return null;
+            }
+        }
+
+        /// <inheritdoc/>
         public async Task<bool> DeleteBlobsAsync(string blobName)
         {
             BlobClient blobClient = this.blobContainerClient.GetBlobClient(blobName);
@@ -168,6 +204,20 @@ namespace NotificationService.Data
             {
                 this.logger.TraceWarning($"BlobStorageClient - Method: {nameof(this.DeleteBlobsAsync)} - No blob found with name {blobName}.");
                 return false;
+            }
+        }
+
+        private void GetAttachmentBlobContainerClient(string containerName)
+        {
+            string container = containerName?.ToLowerInvariant();
+            this.attachmentBlobContainerClient = new BlobContainerClient(this.storageAccountSetting.ConnectionString, container);
+            if (!this.attachmentBlobContainerClient.Exists())
+            {
+                this.logger.TraceWarning($"BlobStorageClient - Method: {nameof(this.GetAttachmentBlobContainerClient)} - No container found with name {containerName}.");
+
+                var response = this.attachmentBlobContainerClient.CreateIfNotExists();
+
+                this.attachmentBlobContainerClient = new BlobContainerClient(this.storageAccountSetting.ConnectionString, container);
             }
         }
     }

--- a/NotificationService/NotificationService.Data/CloudStorage/ICloudStorageClient.cs
+++ b/NotificationService/NotificationService.Data/CloudStorage/ICloudStorageClient.cs
@@ -41,11 +41,10 @@ namespace NotificationService.Data
         /// Uploads the Attachment to the blob.
         /// </summary>
         /// <param name="applicationName">Application Name to make the container.</param>
-        /// <param name="notificationId">Notification Id for the Folder.</param>
-        /// <param name="fileName">File Name for the name of the blob.</param>
+        /// <param name="blobPath">Path of the blob to store the content.</param>
         /// <param name="content">Blob Content.</param>
         /// <returns>The Blob URI, till the folder level.</returns>
-        Task<string> UploadAttachmentToBlobAsync(string applicationName, string notificationId, string fileName, string content);
+        Task<string> UploadAttachmentToBlobAsync(string applicationName, string blobPath, string content);
 
         /// <summary>
         /// Downloads the content from the blob as a stream.
@@ -53,6 +52,14 @@ namespace NotificationService.Data
         /// <param name="blobName">Blob name.</param>
         /// <returns>Blob content.</returns>
         Task<string> DownloadBlobAsync(string blobName);
+
+        /// <summary>
+        /// Downloads attachment from blob.
+        /// </summary>
+        /// <param name="applicationName">ApplicationName to identify the container.</param>
+        /// <param name="blobPath">Path of the blob to read the content.</param>
+        /// <returns>The base64 encoded content.</returns>
+        Task<string> DownloadAttachmentFromBlobAsync(string applicationName, string blobPath);
 
         /// <summary>
         /// Deletes the blob.

--- a/NotificationService/NotificationService.Data/CloudStorage/ICloudStorageClient.cs
+++ b/NotificationService/NotificationService.Data/CloudStorage/ICloudStorageClient.cs
@@ -38,6 +38,16 @@ namespace NotificationService.Data
         Task<string> UploadBlobAsync(string blobName, string content);
 
         /// <summary>
+        /// Uploads the Attachment to the blob.
+        /// </summary>
+        /// <param name="applicationName">Application Name to make the container.</param>
+        /// <param name="notificationId">Notification Id for the Folder.</param>
+        /// <param name="fileName">File Name for the name of the blob.</param>
+        /// <param name="content">Blob Content.</param>
+        /// <returns>The Blob URI, till the folder level.</returns>
+        Task<string> UploadAttachmentToBlobAsync(string applicationName, string notificationId, string fileName, string content);
+
+        /// <summary>
         /// Downloads the content from the blob as a stream.
         /// </summary>
         /// <param name="blobName">Blob name.</param>

--- a/NotificationService/NotificationService.Data/Interfaces/IEmailNotificationRepository.cs
+++ b/NotificationService/NotificationService.Data/Interfaces/IEmailNotificationRepository.cs
@@ -21,8 +21,9 @@ namespace NotificationService.Data
         /// Gets the email notification items from database for the input ids.
         /// </summary>
         /// <param name="notificationIds">List of notifications ids.</param>
+        /// <param name="applicationName">The Application Name (Optional).</param>
         /// <returns>List of notitication items corresponding to input ids.</returns>
-        Task<IList<EmailNotificationItemEntity>> GetEmailNotificationItemEntities(IList<string> notificationIds);
+        Task<IList<EmailNotificationItemEntity>> GetEmailNotificationItemEntities(IList<string> notificationIds, string applicationName = null);
 
         /// <summary>
         /// Gets the email notification item from database for the input id.
@@ -35,8 +36,9 @@ namespace NotificationService.Data
         /// Creates entities in database for the input email notification items.
         /// </summary>
         /// <param name="emailNotificationItemEntities">List of <see cref="EmailNotificationItemEntity"/>.</param>
+        /// <param name="applicationName">The applicationName (Optional).</param>
         /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
-        Task CreateEmailNotificationItemEntities(IList<EmailNotificationItemEntity> emailNotificationItemEntities);
+        Task CreateEmailNotificationItemEntities(IList<EmailNotificationItemEntity> emailNotificationItemEntities, string applicationName = null);
 
         /// <summary>
         /// Saves the changes on email notification entities into database.

--- a/NotificationService/NotificationService.Data/Interfaces/IMailAttachmentRepository.cs
+++ b/NotificationService/NotificationService.Data/Interfaces/IMailAttachmentRepository.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace NotificationService.Data
+{
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using NotificationService.Contracts;
+
+    /// <summary>
+    /// Repository interface for all Mail Attachment Items.
+    /// </summary>
+    public interface IMailAttachmentRepository
+    {
+        /// <summary>
+        /// Upload Attachment to the storage provider.
+        /// </summary>
+        /// <param name="emailNotificationItemEntities">The Entities to read the attachment content from.</param>
+        /// <param name="notificationType">Notification Type to create path.</param>
+        /// <param name="applicationName">ApplicationName to create container.</param>
+        /// <returns>Updated Notification Entities with the Attachment Reference.</returns>
+        Task<IList<EmailNotificationItemEntity>> UploadAttachment(IList<EmailNotificationItemEntity> emailNotificationItemEntities, string notificationType, string applicationName);
+
+        /// <summary>
+        /// Download Attachment from the storage provider from the reference.
+        /// </summary>
+        /// <param name="emailNotificationItemEntities">Entities to get the reference from.</param>
+        /// <param name="applicationName">The applicationName to get the container.</param>
+        /// <returns>Updated entities with attachments.</returns>
+        Task<IList<EmailNotificationItemEntity>> DownloadAttachment(IList<EmailNotificationItemEntity> emailNotificationItemEntities, string applicationName);
+    }
+}

--- a/NotificationService/NotificationService.Data/Repositories/MailAttachmentRepository.cs
+++ b/NotificationService/NotificationService.Data/Repositories/MailAttachmentRepository.cs
@@ -1,0 +1,113 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace NotificationService.Data.Repositories
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using Microsoft.Extensions.Logging;
+    using Newtonsoft.Json;
+    using NotificationService.Contracts;
+
+    /// <summary>
+    /// The Mail Attachment Repositoy class.
+    /// </summary>
+    public class MailAttachmentRepository : IMailAttachmentRepository
+    {
+        /// <summary>
+        /// Instance of <see cref="ILogger"/>.
+        /// </summary>
+        private readonly ILogger logger;
+
+        /// <summary>
+        /// Instance of <see cref="ICloudStorageClient"/>.
+        /// </summary>
+        private readonly ICloudStorageClient cloudStorageClient;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MailAttachmentRepository"/> class.
+        /// </summary>
+        /// <param name="logger">The Logger instance.</param>
+        /// <param name="cloudStorageClient">The Cloud Storage Client instance.</param>
+        public MailAttachmentRepository(ILogger logger, ICloudStorageClient cloudStorageClient)
+        {
+            this.logger = logger;
+            this.cloudStorageClient = cloudStorageClient;
+        }
+
+        /// <inheritdoc/>
+        public async Task<IList<EmailNotificationItemEntity>> UploadAttachment(IList<EmailNotificationItemEntity> emailNotificationItemEntities, string notificationType, string applicationName)
+        {
+            this.logger.LogInformation($"Started {nameof(this.UploadAttachment)} method of {nameof(MailAttachmentRepository)}.");
+            IList<EmailNotificationItemEntity> notificationEntities = new List<EmailNotificationItemEntity>();
+            if (!(emailNotificationItemEntities is null) && emailNotificationItemEntities.Count > 0)
+            {
+                foreach (var item in emailNotificationItemEntities)
+                {
+                    EmailNotificationItemEntity notificationEntity = item;
+                    if (item.Attachments.Any())
+                    {
+                        List<NotificationAttachmentReference> attachmentReferences = new List<NotificationAttachmentReference>();
+                        string blobReference = string.Empty;
+                        foreach (var attachment in item.Attachments)
+                        {
+                            string blobPath = string.Concat(notificationType, "/", item.NotificationId, "/", attachment.FileName);
+                            blobReference = await this.cloudStorageClient.UploadAttachmentToBlobAsync(applicationName, blobPath, attachment.FileBase64).ConfigureAwait(false);
+                            attachmentReferences.Add(new NotificationAttachmentReference
+                            {
+                                FileName = attachment.FileName,
+                                FileReference = blobReference,
+                                IsInline = attachment.IsInline,
+                            });
+                        }
+
+                        notificationEntity.AttachmentReference = JsonConvert.SerializeObject(attachmentReferences);
+                    }
+
+                    notificationEntities.Add(notificationEntity);
+                }
+            }
+
+            this.logger.LogInformation($"Finished {nameof(this.UploadAttachment)} method of {nameof(MailAttachmentRepository)}.");
+            return notificationEntities;
+        }
+
+        /// <inheritdoc/>
+        public async Task<IList<EmailNotificationItemEntity>> DownloadAttachment(IList<EmailNotificationItemEntity> emailNotificationItemEntities, string applicationName)
+        {
+            this.logger.LogInformation($"Started {nameof(this.DownloadAttachment)} method of {nameof(MailAttachmentRepository)}.");
+            IList<EmailNotificationItemEntity> notificationEntities = new List<EmailNotificationItemEntity>();
+            if (!(emailNotificationItemEntities is null) && emailNotificationItemEntities.Count > 0)
+            {
+                foreach (var item in emailNotificationItemEntities)
+                {
+                    EmailNotificationItemEntity notificationEntity = item;
+                    if (!string.IsNullOrEmpty(item.AttachmentReference))
+                    {
+                        List<NotificationAttachmentReference> attachmentReferences = JsonConvert.DeserializeObject<List<NotificationAttachmentReference>>(item.AttachmentReference);
+                        IList<NotificationAttachmentEntity> attachments = new List<NotificationAttachmentEntity>();
+                        foreach (var reference in attachmentReferences)
+                        {
+                            string content = await this.cloudStorageClient.DownloadAttachmentFromBlobAsync(applicationName, reference.FileReference).ConfigureAwait(false);
+                            NotificationAttachmentEntity attachment = new NotificationAttachmentEntity()
+                            {
+                                FileBase64 = content,
+                                FileName = reference.FileName,
+                                IsInline = reference.IsInline,
+                            };
+                            attachments.Add(attachment);
+                        }
+
+                        notificationEntity.Attachments = attachments;
+                    }
+
+                    notificationEntities.Add(notificationEntity);
+                }
+            }
+
+            this.logger.LogInformation($"Finished {nameof(this.DownloadAttachment)} method of {nameof(MailAttachmentRepository)}.");
+            return notificationEntities;
+        }
+    }
+}

--- a/NotificationService/NotificationService.Data/Repositories/TableStorageEmailRepository.cs
+++ b/NotificationService/NotificationService.Data/Repositories/TableStorageEmailRepository.cs
@@ -250,6 +250,7 @@ namespace NotificationService.Data.Repositories
             emailNotificationItemTableEntity.RowKey = emailNotificationItemEntity.NotificationId;
             emailNotificationItemTableEntity.Application = emailNotificationItemEntity.Application;
             emailNotificationItemTableEntity.Attachments = emailNotificationItemEntity.Attachments;
+            emailNotificationItemTableEntity.AttachmentReference = emailNotificationItemEntity.AttachmentReference;
             emailNotificationItemTableEntity.BCC = emailNotificationItemEntity.BCC;
             emailNotificationItemTableEntity.Body = emailNotificationItemEntity.Body;
             emailNotificationItemTableEntity.CC = emailNotificationItemEntity.CC;
@@ -388,6 +389,7 @@ namespace NotificationService.Data.Repositories
             emailNotificationItemEntity.RowKey = emailNotificationItemTableEntity.NotificationId;
             emailNotificationItemEntity.Application = emailNotificationItemTableEntity.Application;
             emailNotificationItemEntity.Attachments = emailNotificationItemTableEntity.Attachments;
+            emailNotificationItemEntity.AttachmentReference = emailNotificationItemTableEntity.AttachmentReference;
             emailNotificationItemEntity.BCC = emailNotificationItemTableEntity.BCC;
             emailNotificationItemEntity.Body = emailNotificationItemTableEntity.Body;
             emailNotificationItemEntity.CC = emailNotificationItemTableEntity.CC;

--- a/NotificationService/NotificationService.UnitTests/BusinessLibrary/V1/EmailManager/EmailManagerTests.cs
+++ b/NotificationService/NotificationService.UnitTests/BusinessLibrary/V1/EmailManager/EmailManagerTests.cs
@@ -72,6 +72,14 @@ namespace NotificationService.UnitTests.BusinessLibrary.V1.EmailManager
         /// </value>
         public Mock<IEmailNotificationRepository> EmailNotificationRepo { get; set; }
 
+        /// <summary>
+        /// Gets or sets the Cloud Storage Client.
+        /// </summary>
+        /// <value>
+        /// the Cloud Storage Client.
+        /// </value>
+        public Mock<ICloudStorageClient> CloudStorageClient { get; set; }
+
         public EmailManagerTests()
         {
             this.Logger = new Mock<ILogger>().Object;
@@ -81,6 +89,7 @@ namespace NotificationService.UnitTests.BusinessLibrary.V1.EmailManager
             this.Configuration = new Mock<IConfiguration>();
             this.EmailNotificationRepo = new Mock<IEmailNotificationRepository>();
             this.RepositoryFactory = new Mock<IRepositoryFactory>();
+            this.CloudStorageClient = new Mock<ICloudStorageClient>();
             _ = this.Configuration.Setup(x => x[Constants.StorageType]).Returns("StorageAccount");
             _ = this.RepositoryFactory.Setup(x => x.GetRepository(It.IsAny<StorageType>())).Returns(this.EmailNotificationRepo.Object);
         }
@@ -92,7 +101,7 @@ namespace NotificationService.UnitTests.BusinessLibrary.V1.EmailManager
         [Test]
         public async Task CreateMeetingNotificationEntitiesTests()
         {
-            var emailManager = new EmailManager(this.Configuration.Object, this.RepositoryFactory.Object, this.Logger, this.EncryptionService.Object, this.TemplateManager.Object, this.TemplateMerge.Object);
+            var emailManager = new EmailManager(this.Configuration.Object, this.RepositoryFactory.Object, this.Logger, this.EncryptionService.Object, this.TemplateManager.Object, this.TemplateMerge.Object, this.CloudStorageClient.Object);
             var meetingNotificationItems = new List<MeetingNotificationItem>
             {
                 new MeetingNotificationItem { RecrurrenceEndDate = DateTime.UtcNow.AddHours(1), MeetingStartTime = DateTime.UtcNow.AddHours(1), MeetingEndTime = DateTime.UtcNow },
@@ -109,7 +118,7 @@ namespace NotificationService.UnitTests.BusinessLibrary.V1.EmailManager
         [Test]
         public void NotificationEntitiesToResponseTests()
         {
-            var emailManager = new EmailManager(this.Configuration.Object, this.RepositoryFactory.Object, this.Logger, this.EncryptionService.Object, this.TemplateManager.Object, this.TemplateMerge.Object);
+            var emailManager = new EmailManager(this.Configuration.Object, this.RepositoryFactory.Object, this.Logger, this.EncryptionService.Object, this.TemplateManager.Object, this.TemplateMerge.Object, this.CloudStorageClient.Object);
             var meetingNotificationItems = new List<MeetingNotificationItemEntity>
             {
                 new MeetingNotificationItemEntity

--- a/NotificationService/NotificationService.UnitTests/BusinessLibrary/V1/EmailManager/EmailManagerTestsBase.cs
+++ b/NotificationService/NotificationService.UnitTests/BusinessLibrary/V1/EmailManager/EmailManagerTestsBase.cs
@@ -292,7 +292,7 @@ namespace NotificationService.UnitTests.BusinessLibrary.V1.EmailManager
             _ = this.TemplateMerge
                 .Setup(tmr => tmr.CreateMailBodyUsingTemplate(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
                 .Returns(mergedTemplate);
-            this.EmailManager = new EmailManager(this.Configuration, this.EmailNotificationRepository.Object, this.Logger, this.EncryptionService.Object, this.TemplateManager.Object, this.TemplateMerge.Object);
+            this.EmailManager = new EmailManager(this.Configuration, this.EmailNotificationRepository.Object, this.Logger, this.EncryptionService.Object, this.TemplateManager.Object, this.TemplateMerge.Object, this.CloudStorageClient.Object);
 
             this.MSGraphNotificationProvider = new MSGraphNotificationProvider(
                 this.Configuration,

--- a/NotificationService/NotificationService.UnitTests/BusinessLibrary/V1/EmailManager/EmailManagerTestsBase.cs
+++ b/NotificationService/NotificationService.UnitTests/BusinessLibrary/V1/EmailManager/EmailManagerTestsBase.cs
@@ -262,7 +262,7 @@ namespace NotificationService.UnitTests.BusinessLibrary.V1.EmailManager
                 .Returns(Task.FromResult(It.IsAny<bool>()));
 
             _ = this.EmailNotificationRepository
-                .Setup(repository => repository.GetRepository(StorageType.StorageAccount).CreateEmailNotificationItemEntities(It.IsAny<IList<EmailNotificationItemEntity>>()))
+                .Setup(repository => repository.GetRepository(StorageType.StorageAccount).CreateEmailNotificationItemEntities(It.IsAny<IList<EmailNotificationItemEntity>>(), It.IsAny<string>()))
                 .Returns(Task.CompletedTask);
 
             _ = this.EmailNotificationRepository
@@ -270,7 +270,7 @@ namespace NotificationService.UnitTests.BusinessLibrary.V1.EmailManager
                 .Returns(Task.CompletedTask);
 
             _ = this.EmailNotificationRepository
-                .Setup(repository => repository.GetRepository(StorageType.StorageAccount).GetEmailNotificationItemEntities(It.IsAny<IList<string>>()))
+                .Setup(repository => repository.GetRepository(StorageType.StorageAccount).GetEmailNotificationItemEntities(It.IsAny<IList<string>>(), It.IsAny<string>()))
                 .Returns(Task.FromResult(emailNotificationItemEntities));
 
             _ = this.CloudStorageClient

--- a/NotificationService/NotificationService.UnitTests/BusinessLibrary/V1/EmailManager/ProcessEmailNotificationsTests.cs
+++ b/NotificationService/NotificationService.UnitTests/BusinessLibrary/V1/EmailManager/ProcessEmailNotificationsTests.cs
@@ -46,7 +46,7 @@ namespace NotificationService.UnitTests.BusinesLibrary.V1.EmailManager
         {
             Task<IList<NotificationResponse>> result = this.EmailServiceManager.ProcessEmailNotifications(this.ApplicationName, new QueueNotificationItem { NotificationIds = new string[] { Guid.NewGuid().ToString() } });
             Assert.AreEqual(result.Status.ToString(), "RanToCompletion");
-            this.EmailNotificationRepository.Verify(repo => repo.GetRepository(StorageType.StorageAccount).GetEmailNotificationItemEntities(It.IsAny<IList<string>>()), Times.Once);
+            this.EmailNotificationRepository.Verify(repo => repo.GetRepository(StorageType.StorageAccount).GetEmailNotificationItemEntities(It.IsAny<IList<string>>(), It.IsAny<string>()), Times.Once);
             this.EmailNotificationRepository.Verify(repo => repo.GetRepository(StorageType.StorageAccount).UpdateEmailNotificationItemEntities(It.IsAny<IList<EmailNotificationItemEntity>>()), Times.Once);
             Assert.Pass();
         }
@@ -62,7 +62,7 @@ namespace NotificationService.UnitTests.BusinesLibrary.V1.EmailManager
 
             Task<IList<NotificationResponse>> result = this.EmailServiceManager.ProcessEmailNotifications(this.ApplicationName, new QueueNotificationItem { NotificationIds = new string[] { Guid.NewGuid().ToString() } });
             Assert.AreEqual(result.Status.ToString(), "RanToCompletion");
-            this.EmailNotificationRepository.Verify(repo => repo.GetRepository(StorageType.StorageAccount).GetEmailNotificationItemEntities(It.IsAny<IList<string>>()), Times.Once);
+            this.EmailNotificationRepository.Verify(repo => repo.GetRepository(StorageType.StorageAccount).GetEmailNotificationItemEntities(It.IsAny<IList<string>>(), It.IsAny<string>()), Times.Once);
             this.EmailNotificationRepository.Verify(repo => repo.GetRepository(StorageType.StorageAccount).UpdateEmailNotificationItemEntities(It.IsAny<IList<EmailNotificationItemEntity>>()), Times.Once);
             Assert.Pass();
         }
@@ -109,7 +109,7 @@ namespace NotificationService.UnitTests.BusinesLibrary.V1.EmailManager
 
             Task<IList<NotificationResponse>> result = this.EmailServiceManager.ProcessEmailNotifications(this.ApplicationName, new QueueNotificationItem { NotificationIds = new string[] { Guid.NewGuid().ToString() } });
             Assert.AreEqual(result.Status.ToString(), "RanToCompletion");
-            this.EmailNotificationRepository.Verify(repo => repo.GetRepository(StorageType.StorageAccount).GetEmailNotificationItemEntities(It.IsAny<IList<string>>()), Times.Once);
+            this.EmailNotificationRepository.Verify(repo => repo.GetRepository(StorageType.StorageAccount).GetEmailNotificationItemEntities(It.IsAny<IList<string>>(), It.IsAny<string>()), Times.Once);
             this.EmailNotificationRepository.Verify(repo => repo.GetRepository(StorageType.StorageAccount).UpdateEmailNotificationItemEntities(It.IsAny<IList<EmailNotificationItemEntity>>()), Times.Once);
             Assert.Pass();
         }
@@ -176,13 +176,13 @@ namespace NotificationService.UnitTests.BusinesLibrary.V1.EmailManager
             };
 
             _ = this.EmailNotificationRepository
-                .Setup(repository => repository.GetRepository(StorageType.StorageAccount).GetEmailNotificationItemEntities(It.IsAny<List<string>>()))
+                .Setup(repository => repository.GetRepository(StorageType.StorageAccount).GetEmailNotificationItemEntities(It.IsAny<List<string>>(), It.IsAny<string>()))
                 .Returns(Task.FromResult(emailNotificationItemEntities));
 
             this.EmailServiceManager = new EmailServiceManager(this.Configuration, this.EmailNotificationRepository.Object, this.CloudStorageClient.Object, this.Logger, this.NotificationProviderFactory.Object, this.EmailManager);
             var result = await this.EmailServiceManager.ProcessEmailNotifications(this.ApplicationName, new QueueNotificationItem { NotificationIds = new string[] { Guid.NewGuid().ToString() }, IgnoreAlreadySent = true }).ConfigureAwait(false);
             Assert.AreEqual(result.Where(x => x.Status == NotificationItemStatus.Sent).Count(), 2);
-            this.EmailNotificationRepository.Verify(repo => repo.GetRepository(StorageType.StorageAccount).GetEmailNotificationItemEntities(It.IsAny<IList<string>>()), Times.Once);
+            this.EmailNotificationRepository.Verify(repo => repo.GetRepository(StorageType.StorageAccount).GetEmailNotificationItemEntities(It.IsAny<IList<string>>(), It.IsAny<string>()), Times.Once);
             this.EmailNotificationRepository.Verify(repo => repo.GetRepository(StorageType.StorageAccount).UpdateEmailNotificationItemEntities(It.IsAny<IList<EmailNotificationItemEntity>>()), Times.Never);
             Assert.Pass();
         }
@@ -248,7 +248,7 @@ namespace NotificationService.UnitTests.BusinesLibrary.V1.EmailManager
             };
 
             _ = this.EmailNotificationRepository
-                .Setup(repository => repository.GetRepository(StorageType.StorageAccount).GetEmailNotificationItemEntities(It.IsAny<IList<string>>()))
+                .Setup(repository => repository.GetRepository(StorageType.StorageAccount).GetEmailNotificationItemEntities(It.IsAny<IList<string>>(), It.IsAny<string>()))
                 .Returns(Task.FromResult(emailNotificationItemEntities));
 
             _ = this.MsGraphProvider
@@ -275,7 +275,7 @@ namespace NotificationService.UnitTests.BusinesLibrary.V1.EmailManager
             Assert.AreEqual(result.Status.ToString(), "RanToCompletion");
             Assert.AreEqual(2, result.Result.Where(x => x.Status == NotificationItemStatus.Sent).Count());
 
-            this.EmailNotificationRepository.Verify(repo => repo.GetRepository(StorageType.StorageAccount).GetEmailNotificationItemEntities(It.IsAny<IList<string>>()), Times.Once);
+            this.EmailNotificationRepository.Verify(repo => repo.GetRepository(StorageType.StorageAccount).GetEmailNotificationItemEntities(It.IsAny<IList<string>>(), It.IsAny<string>()), Times.Once);
             this.EmailNotificationRepository.Verify(repo => repo.GetRepository(StorageType.StorageAccount).UpdateEmailNotificationItemEntities(It.IsAny<IList<EmailNotificationItemEntity>>()), Times.Once);
         }
 
@@ -359,7 +359,7 @@ namespace NotificationService.UnitTests.BusinesLibrary.V1.EmailManager
                 .Build();
 
             _ = this.EmailNotificationRepository
-                .Setup(repository => repository.GetRepository(StorageType.StorageAccount).GetEmailNotificationItemEntities(It.IsAny<IList<string>>()))
+                .Setup(repository => repository.GetRepository(StorageType.StorageAccount).GetEmailNotificationItemEntities(It.IsAny<IList<string>>(), It.IsAny<string>()))
                 .Returns(Task.FromResult(emailNotificationItemEntities));
 
             _ = this.MsGraphProvider
@@ -370,14 +370,14 @@ namespace NotificationService.UnitTests.BusinesLibrary.V1.EmailManager
 
             Task<IList<NotificationResponse>> result = this.EmailServiceManager.ProcessEmailNotifications(this.ApplicationName, new QueueNotificationItem { NotificationIds = new string[] { Guid.NewGuid().ToString() }, IgnoreAlreadySent = true });
             Assert.AreEqual(result.Status.ToString(), "RanToCompletion");
-            this.EmailNotificationRepository.Verify(repo => repo.GetRepository(StorageType.StorageAccount).GetEmailNotificationItemEntities(It.IsAny<IList<string>>()), Times.Once);
+            this.EmailNotificationRepository.Verify(repo => repo.GetRepository(StorageType.StorageAccount).GetEmailNotificationItemEntities(It.IsAny<IList<string>>(), It.IsAny<string>()), Times.Once);
             this.EmailNotificationRepository.Verify(repo => repo.GetRepository(StorageType.StorageAccount).UpdateEmailNotificationItemEntities(It.IsAny<IList<EmailNotificationItemEntity>>()), Times.Once);
             Assert.Pass();
             Assert.AreEqual(1, result.Result.Where(x => x.Status == NotificationItemStatus.Failed).Count());
             Assert.IsTrue(result.Result.FirstOrDefault(x => x.Status == NotificationItemStatus.Failed).ErrorMessage.Contains("No active/valid email account exists for the application"));
             Assert.AreEqual(1, result.Result.Where(x => x.Status == NotificationItemStatus.Sent).Count());
 
-            this.EmailNotificationRepository.Verify(repo => repo.GetRepository(StorageType.StorageAccount).GetEmailNotificationItemEntities(It.IsAny<IList<string>>()), Times.Once);
+            this.EmailNotificationRepository.Verify(repo => repo.GetRepository(StorageType.StorageAccount).GetEmailNotificationItemEntities(It.IsAny<IList<string>>(), It.IsAny<string>()), Times.Once);
             this.EmailNotificationRepository.Verify(repo => repo.GetRepository(StorageType.StorageAccount).UpdateEmailNotificationItemEntities(It.IsAny<IList<EmailNotificationItemEntity>>()), Times.Once);
         }
 
@@ -458,7 +458,7 @@ namespace NotificationService.UnitTests.BusinesLibrary.V1.EmailManager
                 .Build();
 
             _ = this.EmailNotificationRepository
-                .Setup(repository => repository.GetRepository(StorageType.StorageAccount).GetEmailNotificationItemEntities(It.IsAny<IList<string>>()))
+                .Setup(repository => repository.GetRepository(StorageType.StorageAccount).GetEmailNotificationItemEntities(It.IsAny<IList<string>>(), It.IsAny<string>()))
                 .Returns(Task.FromResult(emailNotificationItemEntities));
 
             _ = this.MsGraphProvider
@@ -469,11 +469,11 @@ namespace NotificationService.UnitTests.BusinesLibrary.V1.EmailManager
 
             Task<IList<NotificationResponse>> result = this.EmailServiceManager.ProcessEmailNotifications(this.ApplicationName, new QueueNotificationItem { NotificationIds = new string[] { Guid.NewGuid().ToString() }, IgnoreAlreadySent = true });
             Assert.AreEqual(result.Status.ToString(), "RanToCompletion");
-            this.EmailNotificationRepository.Verify(repo => repo.GetRepository(StorageType.StorageAccount).GetEmailNotificationItemEntities(It.IsAny<IList<string>>()), Times.Once);
+            this.EmailNotificationRepository.Verify(repo => repo.GetRepository(StorageType.StorageAccount).GetEmailNotificationItemEntities(It.IsAny<IList<string>>(), It.IsAny<string>()), Times.Once);
             this.EmailNotificationRepository.Verify(repo => repo.GetRepository(StorageType.StorageAccount).UpdateEmailNotificationItemEntities(It.IsAny<IList<EmailNotificationItemEntity>>()), Times.Once);
             Assert.Pass();
             Assert.AreEqual(1, result.Result.Where(x => x.Status == NotificationItemStatus.FakeMail).Count());
-            this.EmailNotificationRepository.Verify(repo => repo.GetRepository(StorageType.StorageAccount).GetEmailNotificationItemEntities(It.IsAny<IList<string>>()), Times.Once);
+            this.EmailNotificationRepository.Verify(repo => repo.GetRepository(StorageType.StorageAccount).GetEmailNotificationItemEntities(It.IsAny<IList<string>>(), It.IsAny<string>()), Times.Once);
             this.EmailNotificationRepository.Verify(repo => repo.GetRepository(StorageType.StorageAccount).UpdateEmailNotificationItemEntities(It.IsAny<IList<EmailNotificationItemEntity>>()), Times.Once);
         }
 
@@ -544,7 +544,7 @@ namespace NotificationService.UnitTests.BusinesLibrary.V1.EmailManager
                 .Build();
 
             _ = this.EmailNotificationRepository
-                .Setup(repository => repository.GetRepository(StorageType.StorageAccount).GetEmailNotificationItemEntities(It.IsAny<IList<string>>()))
+                .Setup(repository => repository.GetRepository(StorageType.StorageAccount).GetEmailNotificationItemEntities(It.IsAny<IList<string>>(), It.IsAny<string>()))
                 .Returns(Task.FromResult(emailNotificationItemEntities));
 
             _ = this.MsGraphProvider
@@ -555,11 +555,11 @@ namespace NotificationService.UnitTests.BusinesLibrary.V1.EmailManager
 
             Task<IList<NotificationResponse>> result = this.EmailServiceManager.ProcessEmailNotifications(this.ApplicationName, new QueueNotificationItem { NotificationIds = new string[] { Guid.NewGuid().ToString() }, IgnoreAlreadySent = true });
             Assert.AreEqual(result.Status.ToString(), "RanToCompletion");
-            this.EmailNotificationRepository.Verify(repo => repo.GetRepository(StorageType.StorageAccount).GetEmailNotificationItemEntities(It.IsAny<IList<string>>()), Times.Once);
+            this.EmailNotificationRepository.Verify(repo => repo.GetRepository(StorageType.StorageAccount).GetEmailNotificationItemEntities(It.IsAny<IList<string>>(), It.IsAny<string>()), Times.Once);
             this.EmailNotificationRepository.Verify(repo => repo.GetRepository(StorageType.StorageAccount).UpdateEmailNotificationItemEntities(It.IsAny<IList<EmailNotificationItemEntity>>()), Times.Once);
             Assert.Pass();
             Assert.AreEqual(1, result.Result.Where(x => x.Status == NotificationItemStatus.Sent).Count());
-            this.EmailNotificationRepository.Verify(repo => repo.GetRepository(StorageType.StorageAccount).GetEmailNotificationItemEntities(It.IsAny<IList<string>>()), Times.Once);
+            this.EmailNotificationRepository.Verify(repo => repo.GetRepository(StorageType.StorageAccount).GetEmailNotificationItemEntities(It.IsAny<IList<string>>(), It.IsAny<string>()), Times.Once);
             this.EmailNotificationRepository.Verify(repo => repo.GetRepository(StorageType.StorageAccount).UpdateEmailNotificationItemEntities(It.IsAny<IList<EmailNotificationItemEntity>>()), Times.Once);
         }
 
@@ -630,7 +630,7 @@ namespace NotificationService.UnitTests.BusinesLibrary.V1.EmailManager
                 .Build();
 
             _ = this.EmailNotificationRepository
-                .Setup(repository => repository.GetRepository(StorageType.StorageAccount).GetEmailNotificationItemEntities(It.IsAny<IList<string>>()))
+                .Setup(repository => repository.GetRepository(StorageType.StorageAccount).GetEmailNotificationItemEntities(It.IsAny<IList<string>>(), It.IsAny<string>()))
                 .Returns(Task.FromResult(emailNotificationItemEntities));
 
             _ = this.MsGraphProvider
@@ -641,11 +641,11 @@ namespace NotificationService.UnitTests.BusinesLibrary.V1.EmailManager
 
             Task<IList<NotificationResponse>> result = this.EmailServiceManager.ProcessEmailNotifications(this.ApplicationName, new QueueNotificationItem { NotificationIds = new string[] { Guid.NewGuid().ToString() }, IgnoreAlreadySent = true });
             Assert.AreEqual(result.Status.ToString(), "RanToCompletion");
-            this.EmailNotificationRepository.Verify(repo => repo.GetRepository(StorageType.StorageAccount).GetEmailNotificationItemEntities(It.IsAny<IList<string>>()), Times.Once);
+            this.EmailNotificationRepository.Verify(repo => repo.GetRepository(StorageType.StorageAccount).GetEmailNotificationItemEntities(It.IsAny<IList<string>>(), It.IsAny<string>()), Times.Once);
             this.EmailNotificationRepository.Verify(repo => repo.GetRepository(StorageType.StorageAccount).UpdateEmailNotificationItemEntities(It.IsAny<IList<EmailNotificationItemEntity>>()), Times.Once);
             Assert.Pass();
             Assert.AreEqual(1, result.Result.Where(x => x.Status == NotificationItemStatus.Failed && x.ErrorMessage.Contains("toOverride cannot be null or empty in case of SendForReal is false")).Count());
-            this.EmailNotificationRepository.Verify(repo => repo.GetRepository(StorageType.StorageAccount).GetEmailNotificationItemEntities(It.IsAny<IList<string>>()), Times.Once);
+            this.EmailNotificationRepository.Verify(repo => repo.GetRepository(StorageType.StorageAccount).GetEmailNotificationItemEntities(It.IsAny<IList<string>>(), It.IsAny<string>()), Times.Once);
             this.EmailNotificationRepository.Verify(repo => repo.GetRepository(StorageType.StorageAccount).UpdateEmailNotificationItemEntities(It.IsAny<IList<EmailNotificationItemEntity>>()), Times.Once);
         }
 
@@ -717,7 +717,7 @@ namespace NotificationService.UnitTests.BusinesLibrary.V1.EmailManager
                 .Build();
 
             _ = this.EmailNotificationRepository
-                .Setup(repository => repository.GetRepository(StorageType.StorageAccount).GetEmailNotificationItemEntities(It.IsAny<IList<string>>()))
+                .Setup(repository => repository.GetRepository(StorageType.StorageAccount).GetEmailNotificationItemEntities(It.IsAny<IList<string>>(), It.IsAny<string>()))
                 .Returns(Task.FromResult(emailNotificationItemEntities));
 
             _ = this.MsGraphProvider
@@ -728,11 +728,11 @@ namespace NotificationService.UnitTests.BusinesLibrary.V1.EmailManager
 
             Task<IList<NotificationResponse>> result = this.EmailServiceManager.ProcessEmailNotifications(this.ApplicationName, new QueueNotificationItem { NotificationIds = new string[] { Guid.NewGuid().ToString() }, IgnoreAlreadySent = true });
             Assert.AreEqual(result.Status.ToString(), "RanToCompletion");
-            this.EmailNotificationRepository.Verify(repo => repo.GetRepository(StorageType.StorageAccount).GetEmailNotificationItemEntities(It.IsAny<IList<string>>()), Times.Once);
+            this.EmailNotificationRepository.Verify(repo => repo.GetRepository(StorageType.StorageAccount).GetEmailNotificationItemEntities(It.IsAny<IList<string>>(), It.IsAny<string>()), Times.Once);
             this.EmailNotificationRepository.Verify(repo => repo.GetRepository(StorageType.StorageAccount).UpdateEmailNotificationItemEntities(It.IsAny<IList<EmailNotificationItemEntity>>()), Times.Once);
             Assert.Pass();
             Assert.AreEqual(1, result.Result.Where(x => x.Status == NotificationItemStatus.Sent).Count());
-            this.EmailNotificationRepository.Verify(repo => repo.GetRepository(StorageType.StorageAccount).GetEmailNotificationItemEntities(It.IsAny<IList<string>>()), Times.Once);
+            this.EmailNotificationRepository.Verify(repo => repo.GetRepository(StorageType.StorageAccount).GetEmailNotificationItemEntities(It.IsAny<IList<string>>(), It.IsAny<string>()), Times.Once);
             this.EmailNotificationRepository.Verify(repo => repo.GetRepository(StorageType.StorageAccount).UpdateEmailNotificationItemEntities(It.IsAny<IList<EmailNotificationItemEntity>>()), Times.Once);
         }
 
@@ -786,7 +786,7 @@ namespace NotificationService.UnitTests.BusinesLibrary.V1.EmailManager
                 .Build();
 
             _ = this.EmailNotificationRepository
-                .Setup(repository => repository.GetRepository(StorageType.StorageAccount).GetEmailNotificationItemEntities(It.IsAny<IList<string>>()))
+                .Setup(repository => repository.GetRepository(StorageType.StorageAccount).GetEmailNotificationItemEntities(It.IsAny<IList<string>>(), It.IsAny<string>()))
                 .Returns(Task.FromResult(emailNotificationItemEntities));
 
             _ = this.NotificationProviderFactory
@@ -797,7 +797,7 @@ namespace NotificationService.UnitTests.BusinesLibrary.V1.EmailManager
 
             Task<IList<NotificationResponse>> result = this.EmailServiceManager.ProcessEmailNotifications(this.ApplicationName, new QueueNotificationItem { NotificationIds = new string[] { Guid.NewGuid().ToString() }, IgnoreAlreadySent = true });
             Assert.AreEqual(result.Status.ToString(), "RanToCompletion");
-            this.EmailNotificationRepository.Verify(repo => repo.GetRepository(StorageType.StorageAccount).GetEmailNotificationItemEntities(It.IsAny<IList<string>>()), Times.Once);
+            this.EmailNotificationRepository.Verify(repo => repo.GetRepository(StorageType.StorageAccount).GetEmailNotificationItemEntities(It.IsAny<IList<string>>(), It.IsAny<string>()), Times.Once);
             this.EmailNotificationRepository.Verify(repo => repo.GetRepository(StorageType.StorageAccount).UpdateEmailNotificationItemEntities(It.IsAny<IList<EmailNotificationItemEntity>>()), Times.Once);
             Assert.Pass();
         }
@@ -863,7 +863,7 @@ namespace NotificationService.UnitTests.BusinesLibrary.V1.EmailManager
 
             Task<IList<NotificationResponse>> result = this.EmailServiceManager.ProcessEmailNotifications(this.ApplicationName, new QueueNotificationItem { NotificationIds = new string[] { Guid.NewGuid().ToString() }, IgnoreAlreadySent = true });
             Assert.AreEqual(result.Status.ToString(), "RanToCompletion");
-            this.EmailNotificationRepository.Verify(repo => repo.GetRepository(StorageType.StorageAccount).GetEmailNotificationItemEntities(It.IsAny<IList<string>>()), Times.Once);
+            this.EmailNotificationRepository.Verify(repo => repo.GetRepository(StorageType.StorageAccount).GetEmailNotificationItemEntities(It.IsAny<IList<string>>(), It.IsAny<string>()), Times.Once);
             this.EmailNotificationRepository.Verify(repo => repo.GetRepository(StorageType.StorageAccount).UpdateEmailNotificationItemEntities(It.IsAny<IList<EmailNotificationItemEntity>>()), Times.Once);
             Assert.Pass();
         }

--- a/NotificationService/NotificationService.UnitTests/BusinessLibrary/V1/EmailManager/QueueEmailNotificationsTests.cs
+++ b/NotificationService/NotificationService.UnitTests/BusinessLibrary/V1/EmailManager/QueueEmailNotificationsTests.cs
@@ -34,7 +34,7 @@ namespace NotificationService.UnitTests.BusinesLibrary.V1.EmailManager
         {
             Task<IList<NotificationResponse>> result = this.EmailHandlerManager.QueueEmailNotifications(this.ApplicationName, this.EmailNotificationItems);
             Assert.AreEqual(result.Status.ToString(), "RanToCompletion");
-            this.EmailNotificationRepository.Verify(repo => repo.GetRepository(StorageType.StorageAccount).CreateEmailNotificationItemEntities(It.IsAny<IList<EmailNotificationItemEntity>>()), Times.Once);
+            this.EmailNotificationRepository.Verify(repo => repo.GetRepository(StorageType.StorageAccount).CreateEmailNotificationItemEntities(It.IsAny<IList<EmailNotificationItemEntity>>(), It.IsAny<string>()), Times.Once);
             this.CloudStorageClient.Verify(csa => csa.QueueCloudMessages(It.IsAny<CloudQueue>(), It.IsAny<IEnumerable<string>>(), null), Times.Once);
             Assert.Pass();
         }

--- a/NotificationService/NotificationService.UnitTests/BusinessLibrary/V1/EmailManager/SendEmailNotificationsTests.cs
+++ b/NotificationService/NotificationService.UnitTests/BusinessLibrary/V1/EmailManager/SendEmailNotificationsTests.cs
@@ -42,7 +42,7 @@ namespace NotificationService.UnitTests.BusinesLibrary.V1.EmailManager
         {
             Task<IList<NotificationResponse>> result = this.EmailServiceManager.SendEmailNotifications(this.ApplicationName, this.EmailNotificationItems);
             Assert.AreEqual(result.Status.ToString(), "RanToCompletion");
-            this.EmailNotificationRepository.Verify(repo => repo.GetRepository(StorageType.StorageAccount).CreateEmailNotificationItemEntities(It.IsAny<IList<EmailNotificationItemEntity>>()), Times.Once);
+            this.EmailNotificationRepository.Verify(repo => repo.GetRepository(StorageType.StorageAccount).CreateEmailNotificationItemEntities(It.IsAny<IList<EmailNotificationItemEntity>>(), It.IsAny<string>()), Times.Once);
             this.EmailNotificationRepository.Verify(repo => repo.GetRepository(StorageType.StorageAccount).UpdateEmailNotificationItemEntities(It.IsAny<IList<EmailNotificationItemEntity>>()), Times.Once);
             Assert.Pass();
         }
@@ -58,7 +58,7 @@ namespace NotificationService.UnitTests.BusinesLibrary.V1.EmailManager
 
             Task<IList<NotificationResponse>> result = this.EmailServiceManager.SendEmailNotifications(this.ApplicationName, this.EmailNotificationItems);
             Assert.AreEqual(result.Status.ToString(), "RanToCompletion");
-            this.EmailNotificationRepository.Verify(repo => repo.GetRepository(StorageType.StorageAccount).CreateEmailNotificationItemEntities(It.IsAny<IList<EmailNotificationItemEntity>>()), Times.Once);
+            this.EmailNotificationRepository.Verify(repo => repo.GetRepository(StorageType.StorageAccount).CreateEmailNotificationItemEntities(It.IsAny<IList<EmailNotificationItemEntity>>(), It.IsAny<string>()), Times.Once);
             this.EmailNotificationRepository.Verify(repo => repo.GetRepository(StorageType.StorageAccount).UpdateEmailNotificationItemEntities(It.IsAny<IList<EmailNotificationItemEntity>>()), Times.Once);
             Assert.Pass();
         }
@@ -115,7 +115,7 @@ namespace NotificationService.UnitTests.BusinesLibrary.V1.EmailManager
             };
 
             _ = this.EmailNotificationRepository
-                .Setup(repository => repository.GetRepository(StorageType.StorageAccount).GetEmailNotificationItemEntities(It.IsAny<IList<string>>()))
+                .Setup(repository => repository.GetRepository(StorageType.StorageAccount).GetEmailNotificationItemEntities(It.IsAny<IList<string>>(), It.IsAny<string>()))
                 .Returns(Task.FromResult(emailNotificationItemEntities));
 
             // Test the transient error: Too many Requests/ Request Timeout
@@ -240,7 +240,7 @@ namespace NotificationService.UnitTests.BusinesLibrary.V1.EmailManager
                 .Returns(Task.FromResult(responses));
 
             _ = this.EmailNotificationRepository
-                .Setup(repository => repository.GetRepository(StorageType.StorageAccount).GetEmailNotificationItemEntities(It.IsAny<IList<string>>()))
+                .Setup(repository => repository.GetRepository(StorageType.StorageAccount).GetEmailNotificationItemEntities(It.IsAny<IList<string>>(), It.IsAny<string>()))
                 .Returns(Task.FromResult(emailNotificationItemEntities));
 
             _ = this.TokenHelper

--- a/NotificationService/NotificationService.UnitTests/Data/Repositories/EmailNotificationRepository/EmailNotificationRepositoryTestsBase.cs
+++ b/NotificationService/NotificationService.UnitTests/Data/Repositories/EmailNotificationRepository/EmailNotificationRepositoryTestsBase.cs
@@ -53,6 +53,11 @@ namespace NotificationService.UnitTests.Data.Repositories
         public EmailNotificationRepository EmailNotificationRepository { get; set; }
 
         /// <summary>
+        /// GEts or sets Mail Attachment Reporisotry instance.
+        /// </summary>
+        public Mock<IMailAttachmentRepository> MailAttachmentRepository { get; set; }
+
+        /// <summary>
         /// Gets Test Application name.
         /// </summary>
         public string ApplicationName
@@ -94,6 +99,7 @@ namespace NotificationService.UnitTests.Data.Repositories
             this.CosmosLinqQuery = new Mock<ICosmosLinqQuery>();
             this.CosmosDBQueryClient = new Mock<ICosmosDBQueryClient>();
             this.CosmosContainer = new Mock<Container>();
+            this.MailAttachmentRepository = new Mock<IMailAttachmentRepository>();
             var mockItemResponse = new Mock<ItemResponse<EmailNotificationItemEntity>>();
             var mockFeedIterator = new Mock<FeedIterator<EmailNotificationItemEntity>>();
 
@@ -123,7 +129,7 @@ namespace NotificationService.UnitTests.Data.Repositories
                 .Setup(cdq => cdq.GetCosmosContainer(It.IsAny<string>(), It.IsAny<string>()))
                 .Returns(this.CosmosContainer.Object);
 
-            this.EmailNotificationRepository = new EmailNotificationRepository(this.CosmosDBSetting, this.CosmosDBQueryClient.Object, this.Logger, this.CosmosLinqQuery.Object);
+            this.EmailNotificationRepository = new EmailNotificationRepository(this.CosmosDBSetting, this.CosmosDBQueryClient.Object, this.Logger, this.CosmosLinqQuery.Object, this.MailAttachmentRepository.Object);
         }
     }
 }

--- a/NotificationService/NotificationService.UnitTests/Data/Repositories/TableStorageRepositoryTests.cs
+++ b/NotificationService/NotificationService.UnitTests/Data/Repositories/TableStorageRepositoryTests.cs
@@ -32,6 +32,11 @@ namespace NotificationService.UnitTests.Data.Repositories
         private readonly Mock<ILogger> logger;
 
         /// <summary>
+        /// Instance of <see cref="IMailAttachmentRepository"/>.
+        /// </summary>
+        private readonly Mock<IMailAttachmentRepository> mailAttachmentRepository;
+
+        /// <summary>
         /// Instance of <see cref="meetingHistoryTable"/>.
         /// </summary>
         private Mock<CloudTable> meetingHistoryTable;
@@ -43,6 +48,7 @@ namespace NotificationService.UnitTests.Data.Repositories
         {
             this.cloudStorageClient = new Mock<ITableStorageClient>();
             this.logger = new Mock<ILogger>();
+            this.mailAttachmentRepository = new Mock<IMailAttachmentRepository>();
             this.meetingHistoryTable = new Mock<CloudTable>(new Uri("http://unittests.localhost.com/FakeTable"), (TableClientConfiguration)null);
             _ = this.cloudStorageClient.Setup(x => x.GetCloudTable("MeetingHistory")).Returns(this.meetingHistoryTable.Object);
         }
@@ -57,7 +63,7 @@ namespace NotificationService.UnitTests.Data.Repositories
             IEnumerable<MeetingNotificationItemTableEntity> entities = new List<MeetingNotificationItemTableEntity> { new MeetingNotificationItemTableEntity { NotificationId = "notificationId1" }, new MeetingNotificationItemTableEntity { NotificationId = "notificationId2" } };
             _ = this.meetingHistoryTable.Setup(x => x.ExecuteQuery(It.IsAny<TableQuery<MeetingNotificationItemTableEntity>>(), null, null)).Returns(entities);
             IOptions<StorageAccountSetting> options = Options.Create<StorageAccountSetting>(new StorageAccountSetting { BlobContainerName = "Test", ConnectionString = "Test Con", MailTemplateTableName = "MailTemplate" });
-            var repo = new TableStorageEmailRepository(options, this.cloudStorageClient.Object, this.logger.Object);
+            var repo = new TableStorageEmailRepository(options, this.cloudStorageClient.Object, this.logger.Object, this.mailAttachmentRepository.Object);
             var items = await repo.GetMeetingNotificationItemEntities(new List<string> { "notificationId1", "notificationId2" });
             Assert.IsTrue(items.Count == 2);
         }
@@ -72,7 +78,7 @@ namespace NotificationService.UnitTests.Data.Repositories
             IEnumerable<MeetingNotificationItemTableEntity> entities = new List<MeetingNotificationItemTableEntity> { new MeetingNotificationItemTableEntity { NotificationId = "notificationId1" } };
             _ = this.meetingHistoryTable.Setup(x => x.ExecuteQuery(It.IsAny<TableQuery<MeetingNotificationItemTableEntity>>(), null, null)).Returns(entities);
             IOptions<StorageAccountSetting> options = Options.Create<StorageAccountSetting>(new StorageAccountSetting { BlobContainerName = "Test", ConnectionString = "Test Con", MailTemplateTableName = "MailTemplate" });
-            var repo = new TableStorageEmailRepository(options, this.cloudStorageClient.Object, this.logger.Object);
+            var repo = new TableStorageEmailRepository(options, this.cloudStorageClient.Object, this.logger.Object, this.mailAttachmentRepository.Object);
             var items = await repo.GetMeetingNotificationItemEntity("notificationId1");
             Assert.IsTrue(items.NotificationId == "notificationId1");
         }
@@ -87,7 +93,7 @@ namespace NotificationService.UnitTests.Data.Repositories
             List<MeetingNotificationItemEntity> entities = new List<MeetingNotificationItemEntity> { new MeetingNotificationItemEntity { NotificationId = "notificationId1", Application = "Application", RowKey = "notificationId1" }, new MeetingNotificationItemEntity { NotificationId = "notificationId2", Application = "Application", RowKey = "notificationId2" } };
             this.meetingHistoryTable.Setup(x => x.ExecuteBatchAsync(It.IsAny<TableBatchOperation>(), null, null)).Verifiable();
             IOptions<StorageAccountSetting> options = Options.Create<StorageAccountSetting>(new StorageAccountSetting { BlobContainerName = "Test", ConnectionString = "Test Con", MailTemplateTableName = "MailTemplate" });
-            var repo = new TableStorageEmailRepository(options, this.cloudStorageClient.Object, this.logger.Object);
+            var repo = new TableStorageEmailRepository(options, this.cloudStorageClient.Object, this.logger.Object, this.mailAttachmentRepository.Object);
             await repo.CreateMeetingNotificationItemEntities(entities);
             this.meetingHistoryTable.Verify(x => x.ExecuteBatchAsync(It.IsAny<TableBatchOperation>()), Times.Once);
         }
@@ -104,7 +110,7 @@ namespace NotificationService.UnitTests.Data.Repositories
             List<MeetingNotificationItemEntity> entities = new List<MeetingNotificationItemEntity> { new MeetingNotificationItemEntity { NotificationId = "notificationId1", Application = "Application", RowKey = "notificationId1", ETag = "*" }, new MeetingNotificationItemEntity { NotificationId = "notificationId2", Application = "Application", RowKey = "notificationId2", ETag = "*" } };
             this.meetingHistoryTable.Setup(x => x.ExecuteBatchAsync(It.IsAny<TableBatchOperation>(), null, null)).Verifiable();
             IOptions<StorageAccountSetting> options = Options.Create<StorageAccountSetting>(new StorageAccountSetting { BlobContainerName = "Test", ConnectionString = "Test Con", MailTemplateTableName = "MailTemplate" });
-            var repo = new TableStorageEmailRepository(options, this.cloudStorageClient.Object, this.logger.Object);
+            var repo = new TableStorageEmailRepository(options, this.cloudStorageClient.Object, this.logger.Object, this.mailAttachmentRepository.Object);
             await repo.UpdateMeetingNotificationItemEntities(entities);
             this.meetingHistoryTable.Verify(x => x.ExecuteBatchAsync(It.IsAny<TableBatchOperation>()), Times.Once);
         }

--- a/NotificationService/NotificationService/Startup.cs
+++ b/NotificationService/NotificationService/Startup.cs
@@ -128,6 +128,7 @@ namespace NotificationService
                 .AddScoped<ITableStorageClient, TableStorageClient>()
                 .AddScoped<IMailTemplateManager, MailTemplateManager>()
                 .AddScoped<IMailTemplateRepository, MailTemplateRepository>()
+                .AddScoped<IMailAttachmentRepository, MailAttachmentRepository>()
                 .AddScoped<ITemplateMerge, TemplateMerge>()
                 .AddSingleton<IEmailAccountManager, EmailAccountManager>()
                 .AddScoped<INotificationProviderFactory, NotificationProviderFactory>()

--- a/NotificationService/NotificationService/Startup.cs
+++ b/NotificationService/NotificationService/Startup.cs
@@ -109,8 +109,14 @@ namespace NotificationService
 
             _ = services.AddScoped<INotificationReportManager, NotificationReportManager>()
                 .AddScoped<IEmailManager, EmailManager>(s =>
-                    new EmailManager(this.Configuration, s.GetService<IRepositoryFactory>(), s.GetService<ILogger>(), s.GetService<NotificationService.Common.Encryption.IEncryptionService>(),
-                    s.GetService<IMailTemplateManager>(), s.GetService<ITemplateMerge>()))
+                    new EmailManager(
+                        this.Configuration,
+                        s.GetService<IRepositoryFactory>(),
+                        s.GetService<ILogger>(),
+                        s.GetService<NotificationService.Common.Encryption.IEncryptionService>(),
+                        s.GetService<IMailTemplateManager>(),
+                        s.GetService<ITemplateMerge>(),
+                        s.GetService<ICloudStorageClient>()))
                 .AddScoped<IEmailServiceManager, EmailServiceManager>(s =>
                     new EmailServiceManager(this.Configuration, s.GetService<IRepositoryFactory>(), s.GetService<ICloudStorageClient>(), s.GetService<ILogger>(),
                     s.GetService<INotificationProviderFactory>(), s.GetService<IEmailManager>()))


### PR DESCRIPTION
Added the functionality of uploading the attachments to blob, and saving the blob reference to the Storage provider (Cosmos/Table Storage). The same attachment can be fetched during fetching the Notification Entity.

Blob structure:
```
Container: ApplicationName
│
└───Folder: NotificationType
     │
     └───Folder: NotificationId
         │   Attachment1
         │   Attachment2
         │   ...
```