### PR TITLE
Changing DisplayName to FromAddressDisplayName for Direct Send

### DIFF
--- a/NotificationService/NotificationProviders/DirectSend.Shared/DirectSendMailService.cs
+++ b/NotificationService/NotificationProviders/DirectSend.Shared/DirectSendMailService.cs
@@ -81,7 +81,7 @@ namespace DirectSend
                 message.Cc.AddRange(emailMessage.CcAddresses.Select(x => new MailboxAddress(x.Name, x.Address)));
             }
 
-            message.From.AddRange(emailMessage.FromAddresses.Select(x => new MailboxAddress(this.mailConfiguration.DisplayName, x.Address)));
+            message.From.AddRange(emailMessage.FromAddresses.Select(x => new MailboxAddress(this.mailConfiguration.FromAddressDisplayName, x.Address)));
             message.Importance = MessageImportance.High;
 
             message.Subject = emailMessage.Subject;
@@ -161,7 +161,7 @@ namespace DirectSend
                 message.Cc.AddRange(emailMessage.CcAddresses.Select(x => new MailboxAddress(x.Name, x.Address)));
             }
 
-            message.From.AddRange(emailMessage.FromAddresses.Select(x => new MailboxAddress(this.mailConfiguration.DisplayName, x.Address)));
+            message.From.AddRange(emailMessage.FromAddresses.Select(x => new MailboxAddress(this.mailConfiguration.FromAddressDisplayName, x.Address)));
 
             message.Subject = emailMessage.Subject;
 

--- a/NotificationService/NotificationProviders/DirectSend.Shared/Models/Configurations/SendAccountConfiguration.cs
+++ b/NotificationService/NotificationProviders/DirectSend.Shared/Models/Configurations/SendAccountConfiguration.cs
@@ -22,6 +22,6 @@ namespace DirectSend.Models.Configurations
         /// <value>
         /// The display name.
         /// </value>
-        public string DisplayName { get; set; }
+        public string FromAddressDisplayName { get; set; }
     }
 }

--- a/NotificationService/NotificationProviders/DirectSend.Tests/DirectSendMailServiceTests.cs
+++ b/NotificationService/NotificationProviders/DirectSend.Tests/DirectSendMailServiceTests.cs
@@ -26,7 +26,7 @@ namespace DirectSend.Tests
         [TestMethod()]
         public async Task SendAsyncTest()
         {
-            SendAccountConfiguration sendAccountConfiguration = new SendAccountConfiguration { Address = "TestAddress", DisplayName = "TestDisplayName" };
+            SendAccountConfiguration sendAccountConfiguration = new SendAccountConfiguration { Address = "TestAddress", FromAddressDisplayName = "TestDisplayName" };
             var directSendMailService= new DirectSendMailService(this.mockedClientPool.Object, this.mockedLogger.Object, sendAccountConfiguration);
             var emailMessage = new EmailMessage
             {
@@ -48,7 +48,7 @@ namespace DirectSend.Tests
         [TestMethod()]
         public async Task SendMeetingAsyncTest()
         {
-            SendAccountConfiguration sendAccountConfiguration = new SendAccountConfiguration { Address = "TestAddress", DisplayName = "TestDisplayName" };
+            SendAccountConfiguration sendAccountConfiguration = new SendAccountConfiguration { Address = "TestAddress", FromAddressDisplayName = "TestDisplayName" };
             var directSendMailService = new DirectSendMailService(this.mockedClientPool.Object, this.mockedLogger.Object, sendAccountConfiguration);
             var emailMessage = new EmailMessage
             {
@@ -70,7 +70,7 @@ namespace DirectSend.Tests
         [TestMethod()]
         public async Task SendAsyncTest_Attachments()
         {
-            SendAccountConfiguration sendAccountConfiguration = new SendAccountConfiguration { Address = "TestAddress", DisplayName = "TestDisplayName" };
+            SendAccountConfiguration sendAccountConfiguration = new SendAccountConfiguration { Address = "TestAddress", FromAddressDisplayName = "TestDisplayName" };
             var directSendMailService = new DirectSendMailService(this.mockedClientPool.Object, this.mockedLogger.Object, sendAccountConfiguration);
             var emailMessage = new EmailMessage
             {
@@ -94,7 +94,7 @@ namespace DirectSend.Tests
         [TestMethod()]
         public async Task SendAsyncTest_Exception()
         {
-            SendAccountConfiguration sendAccountConfiguration = new SendAccountConfiguration { Address = "TestAddress", DisplayName = "TestDisplayName" };
+            SendAccountConfiguration sendAccountConfiguration = new SendAccountConfiguration { Address = "TestAddress", FromAddressDisplayName = "TestDisplayName" };
             var directSendMailService = new DirectSendMailService(this.mockedClientPool.Object, this.mockedLogger.Object, sendAccountConfiguration);
             var emailMessage = new EmailMessage
             {

--- a/NotificationService/NotificationService.Common/Configurations/ConfigConstants.cs
+++ b/NotificationService/NotificationService.Common/Configurations/ConfigConstants.cs
@@ -173,7 +173,7 @@
         /// <summary>
         /// A constant for DirectSend DisplayName config key from appsetting.json.
         /// </summary>
-        public static string DirectSendDisplayNameConfigKey = $"{DirectSendSettingConfigSectionKey}:DisplayName";
+        public static string DirectSendFromAddressDisplayNameConfigKey = $"{DirectSendSettingConfigSectionKey}:FromAddressDisplayName";
 
         /// <summary>
         /// A constant for DirectSend SMTPPort config key from appsetting.json.

--- a/NotificationService/NotificationService/Startup.cs
+++ b/NotificationService/NotificationService/Startup.cs
@@ -139,7 +139,7 @@ namespace NotificationService
         {
             _ = services.AddSingleton<SendAccountConfiguration>(new SendAccountConfiguration()
             {
-                DisplayName = this.Configuration[ConfigConstants.DirectSendDisplayNameConfigKey],
+                FromAddressDisplayName = this.Configuration[ConfigConstants.DirectSendFromAddressDisplayNameConfigKey],
             });
 
             if (int.TryParse(this.Configuration[ConfigConstants.DirectSendSMTPPortConfigKey], out int port))


### PR DESCRIPTION
To resolve the confusion between DisplayName and FromAddressDisplayName, replacing DisplayName with FromAddressDisplayName everywhere.