### PR TITLE
fix: fixed email attachment issue

### DIFF
--- a/NotificationService/NotificationService.Contracts/Models/Graph/FileAttachment.cs
+++ b/NotificationService/NotificationService.Contracts/Models/Graph/FileAttachment.cs
@@ -17,7 +17,7 @@ namespace NotificationService.Contracts
         /// Gets the attachment type.
         /// </summary>
         [DataMember(Name = "@odata.type")]
-        public string Type { get; } = "#Microsoft.OutlookServices.FileAttachment";
+        public string Type { get; } = "#microsoft.graph.fileAttachment";
 
         /// <summary>
         /// Gets or sets base-64 encoded contents of the file.


### PR DESCRIPTION
fixes #82

corrected the OData type to `#microsoft.graph.filesystem`
[reference](https://docs.microsoft.com/en-us/graph/api/resources/fileattachment?view=graph-rest-1.0)